### PR TITLE
Addition to lighttpd.conf to Auto-Direct to Captive Portal

### DIFF
--- a/deployables/current/PIInstall.sh
+++ b/deployables/current/PIInstall.sh
@@ -61,7 +61,7 @@ echo "-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_"
 cd ~
 cd configs
 wget https://raw.githubusercontent.com/tomhiggins/anyfesto/master/deployables/current/startpi.sh
-wget https://raw.githubusercontent.com/tomhiggins/anyfesto/master/deployables/current/lighttpd.conf
+wget https://raw.githubusercontent.com/mauricecyril/anyfesto/master/deployables/current/lighttpd.conf
 wget https://raw.githubusercontent.com/tomhiggins/anyfesto/master/deployables/current/vlchosts
 wget https://raw.githubusercontent.com/tomhiggins/anyfesto/master/deployables/current/stream.m3u
 sudo mkdir /etc/vlc 

--- a/deployables/current/lighttpd.conf
+++ b/deployables/current/lighttpd.conf
@@ -13,7 +13,11 @@ server.pid-file             = "/var/run/lighttpd.pid"
 server.username             = "www-data"
 server.groupname            = "www-data"
 server.port                 = 80
-
+$HTTP["host"] != "anyfesto.local" {
+url.redirect = (
+        "^/(.*)$" => "http://anyfesto.local/"
+)
+}
 
 index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )
 url.access-deny             = ( "~", ".inc" )


### PR DESCRIPTION
Hi Tom you can ignore the update to PIInstall.sh. However for the lighttpd.conf if we add:

`$HTTP["host"] != "anyfesto.local" {
url.redirect = (
        "^/(.*)$" => "http://anyfesto.local/"
)
}`

devices that connect to the Anyfesto access point will display the captive pages automatically. 